### PR TITLE
Call udevadm instead of "start udevtrigger"

### DIFF
--- a/bin/fai
+++ b/bin/fai
@@ -98,7 +98,7 @@ fai_init() {
             if [ X$UPSTART_JOB != Xfai ]; then
                 /etc/init.d/udev start
             else
-                test -f /etc/init/udevtrigger.conf && start udevtrigger
+                test -f /etc/init/udevtrigger.conf && udevadm trigger --action=add && udevadm settle
             fi
         fi
         mkdir -p /var/run/network /dev/shm/network # when using initrd kernels


### PR DESCRIPTION
Because /sbin/initctl is symlinked in the NFSROOT (see a470d283), "start
udevtrigger" (introduced with 9a7e17f) won't do anything. This fix calls the
appropriate udevadm calls instead. Without it FAI won't detect any disk in an
upstart environment and partitioning will fail.
See Launchpad #941959, Debian #664774
