### PR TITLE
git bare repo as FAI_CONFIG_SRC fails with "fatal: Not a git repository /var/lib/fai/config/.git"

### DIFF
--- a/lib/get-config-dir-git
+++ b/lib/get-config-dir-git
@@ -55,7 +55,7 @@ else
    echo "Checking out from git"
    # cloning into an existing directory is not allowed
    [ -d $FAI ] && rm -rf $FAI
-   git clone --branch "$gitbranch" "$giturl" $FAI
+   git clone --branch "$gitbranch" "$giturl" $GIT_DIR
    task_error 882 $?
     _git_checkout
 fi


### PR DESCRIPTION
Hi. I was initially using an NFS config source with FAI under wheezy, then I tried to switch to a git url (FAI_CONFIG_SRC=git://myhost/myconfigspace.git). FAI threw a FATAL ERROR.

Inside /var/lib/fai there were not only the files I checked into the git repo but also the git control files (e.g. HEAD, refs/).
IMO the clone command in get-config-dir-git should check out to $GIT_DIR, see the patch. After fixing it, installation is successful.
