### PR TITLE
Fix for multiple archs in the local mirror

### DIFF
--- a/bin/fai-cd
+++ b/bin/fai-cd
@@ -243,7 +243,7 @@ EOF
 
     for i in $dists ; do
         comp=$(find $mirrordir/dists/$i -maxdepth 2 -type d -name "binary-*" | \
-        sed -e "s#$mirrordir/*dists/$i/##" -e 's#/binary-.*##' | tr '\n' " ")
+        sed -e "s#$mirrordir/*dists/$i/##" -e 's#/binary-.*##' | sort -u | tr '\n' " ")
         echo "deb file:/media/mirror $i $comp" >> $nfsrootdir/etc/apt/sources.list
     done
 


### PR DESCRIPTION
reprepro (in fai-mirror) always creates binary-i386 and binary-amd64.
This fix will filter duplicate sections in sources.list
