### PR TITLE
Fix /dev/xvda recognition in device2grub

### DIFF
--- a/bin/device2grub
+++ b/bin/device2grub
@@ -27,7 +27,7 @@ while (<DEVICEMAP>) {
   $map{$olddevice} = $grubdevice;
 }
 
-$device=~ m#^(/dev/(?:[shv]d\D|i2o/hd\D|ida/c\d*d\d*|cciss/c\d*d\d*))p*(\d*)$# || die "Can't match device: $device\n";
+$device=~ m#^(/dev/(?:[shv]d\D|xvd\D|i2o/hd\D|ida/c\d*d\d*|cciss/c\d*d\d*))p*(\d*)$# || die "Can't match device: $device\n";
 my ($disk,$partition) = ($1,$2);
 
 if ($map{$disk}) {


### PR DESCRIPTION
/dev/xvda devices are the identifier for Xen Blockdevices.
Most people will use PV but on Citrix XenServers (commercial)
you have the possibility for running Linux on HVM (not uncommon)
This fixes the recognition of it.
