### PR TITLE
Added the 'f' parameter to ln when creating the symbolic link

### DIFF
--- a/bin/fai-make-nfsroot
+++ b/bin/fai-make-nfsroot
@@ -405,7 +405,7 @@ EOF
     cp -H /etc/localtime etc/localtime
     ln -sf /proc/mounts etc/mtab
 
-    [ -f etc/init/tty1.conf ] || ln -s /usr/sbin/fai etc/init.d/rcS
+    [ -f etc/init/tty1.conf ] || ln -fs /usr/sbin/fai etc/init.d/rcS
     if [ -d etc/init ]; then   # if upstart is available
         find etc/init ! -type d | egrep -v "fai|udev|hostname|mountall|mounted" | xargs -r rm
     fi


### PR DESCRIPTION
Or you will get an error saying that fai couldn't create a symbolic link, when running more then one time fai-setup.
