### PR TITLE
Some setup-storage fix reinstall/preserve/lvm

### DIFF
--- a/lib/setup-storage/Commands.pm
+++ b/lib/setup-storage/Commands.pm
@@ -737,8 +737,8 @@ sub build_lvm_commands {
     &FAI::push_command("vgchange -a n $1", "$pre_deps_vgc", $vg_pre);
     $vg_pre .= ",pv_sigs_removed_$vg" if (&FAI::cleanup_vg($vg));
     my $pre_deps_cl = "";
-    $pre_deps_cl = ",self_cleared_" .
-      join(",self_cleared_", @{ $FAI::current_dev_children{$d} })
+    $pre_deps_cl = ",self_cleared_/dev/$vg/" .
+      join(",self_cleared_/dev/$vg/", @{ $FAI::current_dev_children{$d} })
       if (scalar(@{ $FAI::current_dev_children{$d} }));
     &FAI::push_command("true", "$vg_pre$pre_deps_cl", "self_cleared_VG_$vg");
   }

--- a/lib/setup-storage/Commands.pm
+++ b/lib/setup-storage/Commands.pm
@@ -733,7 +733,7 @@ sub build_lvm_commands {
         if (defined($FAI::current_dev_children{$d}) &&
           scalar(@{ $FAI::current_dev_children{$d} }));
     }
-    $pre_deps_vgc =~ s/^,//; 
+    $pre_deps_vgc =~ s/^,//;
     &FAI::push_command("vgchange -a n $vg", "$pre_deps_vgc", $vg_pre);
     $vg_pre .= ",pv_sigs_removed_$vg" if (&FAI::cleanup_vg($vg));
     my $pre_deps_cl = "";

--- a/lib/setup-storage/Commands.pm
+++ b/lib/setup-storage/Commands.pm
@@ -661,8 +661,11 @@ sub cleanup_vg {
           }
         }
 
+        &FAI::push_command( "vgchange -a y $vg",
+          "", "vg_change_a_y_$vg" );
+
         &FAI::push_command( "wipefs -a /dev/$vg/$lv",
-          "",
+          "vg_change_a_y_$vg",
           "wipefs_$vg/$lv");
         &FAI::push_command( "lvremove -f $vg/$lv",
           "wipefs_$vg/$lv",
@@ -682,12 +685,12 @@ sub cleanup_vg {
   my $vg_destroy_pre = "vgchange_a_n_VG_$vg";
   foreach my $lv (keys %{ $FAI::current_lvm_config{$vg}{volumes} }) {
     my $pre_deps_cl = "";
-    $pre_deps_cl = ",self_cleared_" .
-      join(",self_cleared_", @{ $FAI::current_dev_children{"/dev/$vg/$lv"} })
-        if (defined($FAI::current_dev_children{"/dev/$vg/$lv"}) &&
-          scalar(@{ $FAI::current_dev_children{"/dev/$vg/$lv"} }));
+
+    &FAI::push_command( "vgchange -a y $vg",
+      "", "vg_change_a_y_$vg" );
+
     &FAI::push_command( "wipefs -a /dev/$vg/$lv",
-      "$pre_deps_cl",
+      "vg_change_a_y_$vg",
       "wipefs_$vg/$lv");
     &FAI::push_command( "lvremove -f $vg/$lv",
       "wipefs_$vg/$lv",

--- a/lib/setup-storage/Sizes.pm
+++ b/lib/setup-storage/Sizes.pm
@@ -593,14 +593,14 @@ sub compute_partition_sizes
 
     # align to sector boundary by default
     my $block_size = $current_disk->{sector_size};
-    # align to cylinder boundary for msdos disklabels if at least one of the
-    # partitions has to be preserved, for backward compatibility
-    if ($FAI::configs{$config}{disklabel} eq "msdos" &&
-      $FAI::configs{$config}{preserveparts} == 1) {
-      $block_size = $current_disk->{sector_size} *
-        $current_disk->{bios_sectors_per_track} *
-        $current_disk->{bios_heads};
-    }
+    ## align to cylinder boundary for msdos disklabels if at least one of the
+    ## partitions has to be preserved, for backward compatibility
+    #if ($FAI::configs{$config}{disklabel} eq "msdos" &&
+    #  $FAI::configs{$config}{preserveparts} == 1) {
+    #  $block_size = $current_disk->{sector_size} *
+    #    $current_disk->{bios_sectors_per_track} *
+    #    $current_disk->{bios_heads};
+    #}
     # but user-specified alignment wins no matter what
     defined ($FAI::configs{$config}{align_at}) and
       $block_size = $FAI::configs{$config}{align_at};


### PR DESCRIPTION
After fighting few hours, here are some patches uppon setup-storage.

That fix some issues, when using preserve_reinstall option combined with LVM.

Maybe it needs more testing, but they permit me to install, and reinstall, without loosing data.
