### PR TITLE
install_packages: disable package name checking when using 'aptitude-r'

### DIFF
--- a/bin/install_packages
+++ b/bin/install_packages
@@ -411,7 +411,7 @@ sub mkpackagelist {
 
   # currently we disable the complete checking of package names if aptitude
   # is used. This is because we can't check task names, which are supported by aptitude
-  if ($atype eq "aptitude") {
+  if ($atype eq "aptitude" || $atype eq "aptitude-r") {
     @known=@orig;
     writepackages();
     return;


### PR DESCRIPTION
Hi Thomas:

One minor fix.

Best,
Christoph
