### PR TITLE
Documentation: Correct information about apt/.asc files

### DIFF
--- a/doc/fai-guide.txt
+++ b/doc/fai-guide.txt
@@ -1208,7 +1208,7 @@ that is used by `debconf-set-selections(8)`.
 
 _package_config/_::
 Files with class names contain lists of software packages to be
-installed or removed. Files named '*.asc' are added to the key list of
+installed or removed. Files named 'class.asc' are added to the key list of
 apt.
 
 _scripts/_::
@@ -1683,13 +1683,13 @@ and don't list them otherwise
 
 
 Before installing packages, FAI will add the content of all files
-named _package_config/*.asc_ to the list of apt keys. If your local
+named _package_config/class.asc_ to the list of apt keys. If your local
 repository is signed by your keyid AB12CD34 you can easily add this key,
 so FAI will use it during installation. Use this command for creating
-the '.asc' file:
+the 'class.asc' file:
 
 ----
-faiserver$ gpg -a --export AB12CD34 > /srv/fai/config/package_config/myrepo.asc
+faiserver$ gpg -a --export AB12CD34 > /srv/fai/config/package_config/myclass.asc
 ----
 
 


### PR DESCRIPTION
.asc-gpg files are only added if they are named class.asc
