### PR TITLE
outstanding patches from lp#1040254 and debian bug #759273

### DIFF
--- a/bin/ftar
+++ b/bin/ftar
@@ -54,7 +54,7 @@ extract() {
     fi
 
     echo "ftar: extracting $file to $target/$dir" | tr -s '/'
-    $catname $file | tar -C $target/$dir $vflag -xf -
+    $catname $file | tar -C $target/$dir $vflag --numeric-owner -xf -
     tardone=1
     # if option -1 is set, only one class will be used
     [ $single -eq 1 ] && exit 0

--- a/lib/setup-storage/Parser.pm
+++ b/lib/setup-storage/Parser.pm
@@ -33,6 +33,7 @@ use strict;
 
 use Parse::RecDescent;
 use Storable qw(dclone);
+use Cwd 'abs_path';
 
 package FAI;
 
@@ -106,7 +107,7 @@ sub resolve_disk_shortname {
   ($disk =~ m{^/}) or $disk = "/dev/$disk";
   my @candidates = glob($disk);
   die "Failed to resolve $disk to a unique device name\n" if (scalar(@candidates) > 1);
-  $disk = $candidates[0] if (scalar(@candidates) == 1);
+  $disk = abs_path($candidates[0]) if (scalar(@candidates) == 1);
   die "Device name $disk could not be substituted\n" if ($disk =~ m{[\*\?\[\{\~]});
 
   return $disk;


### PR DESCRIPTION
the abspatch patch was discussed in a pair of email threads some years ago. the patch from https://lists.uni-koeln.de/pipermail/linux-fai/2011-November/009355.html resolves the initial problem but does not address the further issues raised by the original poster in https://lists.uni-koeln.de/pipermail/linux-fai/2012-January/009448.html
cf. https://bugs.launchpad.net/ubuntu/+source/fai/+bug/1040254

the tar-numeric-owner patch resolves a dirinstall issue where the uid/gid on the host system does not match that within the chroot.
cf. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=759273