### PR TITLE
Do not follow existing cdrom0 symlink

### DIFF
--- a/examples/simple/scripts/FAIBASE/20-removable_media
+++ b/examples/simple/scripts/FAIBASE/20-removable_media
@@ -20,7 +20,7 @@ fstabline () {
 
 i=0
 for cdrom in $(cdromlist | tac); do
-    [ $i -eq 0 ] && ln -s cdrom0 $target/media/cdrom
+    [ $i -eq 0 ] && ln -sfn cdrom0 $target/media/cdrom
     mkdir -p $target/media/cdrom$i
     fstabline /dev/$cdrom /media/cdrom$i udf,iso9660 ro,user,noauto 0 0
     i=$(($i + 1))


### PR DESCRIPTION
On softupdate after installation fai placed the cdrom0 symlink into the existing target directory; ending up with:
  /media/cdrom -> cdrom0
  /media/cdrom/cdrom0 -> cdrom0
The second symlink is bogus and should not be created.