### PR TITLE
Emit warning on missing PACKAGES line in config

### DIFF
--- a/bin/install_packages
+++ b/bin/install_packages
@@ -288,7 +288,10 @@ sub readconfig {
 
     # warning if uppercase letters are found (package are always lowercase)
     warn "WARNING: Uppercase character found in package name in line $_\n" if $_ =~ /[A-Z]/;
-    warn "ERROR: PACKAGES .. line missing in $file\n",next unless $type;
+    unless ($type) {
+        warn "ERROR: PACKAGES .. line missing in $file\n";
+        next;
+    }
     push @{$list{$type}}, split if $doit;
     $types{$type}=1 if $doit;   # remember which types are used in package_config
   }


### PR DESCRIPTION
These statements were parsed differently than intended by current perl
interpreters. Only the next statement was executed, the warning was
missing silently.