### PR TITLE
fai-nfs-root must be installed before anything else

### DIFF
--- a/bin/fai-make-nfsroot
+++ b/bin/fai-make-nfsroot
@@ -449,7 +449,9 @@ upgrade_nfsroot() {
     fi
 
     $ROOTCMD apt-get update
-    $ROOTCMD apt-get -yf --no-install-recommends install dracut-network dracut-config-generic fai-nfsroot nfs-common
+    # fai-nfsroot must be sucessfully installed before anything else
+    $ROOTCMD apt-get -yf --no-install-recommends install fai-nfsroot
+    $ROOTCMD apt-get -yf --no-install-recommends install dracut-network dracut-config-generic nfs-common
     $ROOTCMD apt-get -y dist-upgrade
     fdivert /usr/sbin/update-grub
 }


### PR DESCRIPTION
Otherwise e.g. nfs-common will start services and fail