### PR TITLE
FIX: fai-make-nfsroot -k

### DIFF
--- a/bin/fai-make-nfsroot
+++ b/bin/fai-make-nfsroot
@@ -463,6 +463,12 @@ upgrade_nfsroot() {
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 add_packages_nfsroot() {
 
+    # Export all the information we have about the system
+    iarch=$($ROOTCMD dpkg --print-architecture|tr /a-z/ /A-Z/)
+    distro=$(. $NFSROOT/etc/os-release; echo ${ID} ${ID}_${VERSION_ID} | tr '[:lower:].' '[:upper:]_')
+    export classes="NFSROOT $iarch $distro"
+    [ "$verbose" ] && echo Classes are set to $classes
+
     export FAI_ROOT=$NFSROOT
     local err
 


### PR DESCRIPTION
fai-make-nfsroot:add_packages_nfsroot() provides $ENV{classes} for install_packages script. We use the same code from create_nfsroot() function. Before this commit install_packages had @classes empty, so the fai-make-nfsroot -k did not work.