### PR TITLE
docs: consistent usage of key file

### DIFF
--- a/man/setup-storage.8
+++ b/man/setup-storage.8
@@ -140,7 +140,7 @@ The example config space shipped with FAI sources this file in
 scripts/GRUB_PC/10-setup.
 If encryption was configured, a proper
 \fBcrypttab\fP(5)
-file plus keyfiles will be generated.
+file plus key files will be generated.
 .SH EXAMPLES
 \fBsetup-storage\fP configures storage devices according to a FAI disk_config
 file. The full grammar describing the syntax of these disk_config files is
@@ -640,7 +640,7 @@ type ::= primary
 .br
          | luks
 .br
-         /* encrypted partition using LUKS and auto-generate a keyfile */
+         /* encrypted partition using LUKS and auto-generate a key file */
 .br
          | luks:"[^"]+"
 .br


### PR DESCRIPTION
I was searching the documentation, and was annoyed that it said it generated a keyfile, but not where it put the keyfile. Later, I was perusing the same doc, and notice the location of a "key file". I know how to fix this! I looked in the cryptsetup docs, and they use "key file", so I picked that one to be standard.