### PR TITLE
doc: Fix URL for fai-cd

### DIFF
--- a/doc/fai-guide.txt
+++ b/doc/fai-guide.txt
@@ -231,7 +231,7 @@ times. All install clients had a 1Gbit network card installed.
 
 Without further ado, this section will provide a quick and easy demonstration of a fully automatic installation using the FAI CD and a virtual machine.
 
-Just download the CD ISO image from http://fai-project/fai-cd and boot
+Just download the CD ISO image from http://fai-project.org/fai-cd and boot
 your VM using this CD. You will see a grub menu where you can select
 from different installation types.
 


### PR DESCRIPTION
In the FAI Guide, the URL to the FAI CD ISO images is missing the ".org" part. This commit adds it.