### PR TITLE
don't exit hooks/instsoft.DEBIAN on dirinstall

### DIFF
--- a/examples/simple/hooks/instsoft.DEBIAN
+++ b/examples/simple/hooks/instsoft.DEBIAN
@@ -3,7 +3,7 @@
 # if package locales will be installed, then install it early, before
 #  other packages
 
-if [ $FAI_ACTION != "install" ]; then
+if [ $FAI_ACTION != "install" -a $FAI_ACTION != "dirinstall" ]; then
    exit 0
 fi
 


### PR DESCRIPTION
doesn't seem to be any reason this should only run on install instead of both install and dirinstall.  there are a few other places where i'm unsure whether the strict $FAI_ACTION = "install" test is necessary but this looks to be the last one that impacts my particular situation.