### PR TITLE
use apt-key to export gpg key for fai-project.org package repository

### DIFF
--- a/bin/fai-make-nfsroot
+++ b/bin/fai-make-nfsroot
@@ -454,8 +454,8 @@ upgrade_nfsroot() {
     fi
 
     # if we have the keyring on the host, install the key of the fai-project.org package repository
-    if [ -f /usr/share/keyrings/debian-keyring.gpg ]; then
-	HOME=/root gpg --keyring /usr/share/keyrings/debian-keyring.gpg --export 074BCDE4 | chroot $NFSROOT apt-key add -
+    if [ -n "$(apt-key list | grep 074BCDE4)" ]; then
+        HOME=/root apt-key export 074BCDE4 | chroot $NFSROOT apt-key add -
     fi
 
     $ROOTCMD apt-get update


### PR DESCRIPTION
there is no such file /usr/share/keyrings/debian-keyring.gpg on my installation of Debian 8 Jessie
(there is /usr/share/keyrings/debian-archive-keyring.gpg instead)
lets use apt-key to provide more robust solution for gpg-key export