### PR TITLE
On cciss, avoid treating partitions as disks

### DIFF
--- a/lib/fai-disk-info
+++ b/lib/fai-disk-info
@@ -19,4 +19,4 @@ checkdisk() {
 }
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # echo a space separated list of devices and their block size
-( egrep 'md[0-9]{3,}$' /proc/partitions; egrep ' etherd/e[[:digit:]]+\.[[:digit:]]+\b| i2o/hd.+\b| cciss/c.+d.+\b| ida/c.+d.+\b| rd/c.+d.+\b| fio.\b| hd.\b| sd[a-z]{1,2}\b|/disc\b| vd.\b| xvd.\b| nvme[[:digit:]]n1$' /proc/partitions ) | checkdisk
+( egrep 'md[0-9]{3,}$' /proc/partitions; egrep ' etherd/e[[:digit:]]+\.[[:digit:]]+\b| i2o/hd.+\b| cciss/c[[:digit:]]+d[[:digit:]]+\b| ida/c[[:digit:]]+d[[:digit:]]+\b| rd/c[[:digit:]]+d[[:digit:]]+\b| fio.\b| hd.\b| sd[a-z]{1,2}\b|/disc\b| vd.\b| xvd.\b| nvme[[:digit:]]n1$' /proc/partitions ) | checkdisk


### PR DESCRIPTION
The [cciss](http://man7.org/linux/man-pages/man4/cciss.4.html) and other drivers use a c0d1p2 device-numbering scheme, indicating the controller, disk, and partition. When looking for disks, we need to be careful not to include partitions.