### PR TITLE
use full if / then / fi construct for setclasses verbose test

### DIFF
--- a/bin/fai-make-nfsroot
+++ b/bin/fai-make-nfsroot
@@ -187,7 +187,9 @@ setclasses() {
     iarch=$($ROOTCMD dpkg --print-architecture|tr /a-z/ /A-Z/)
     distro=$(. $NFSROOT/etc/os-release; echo ${ID} ${ID}_${VERSION_ID} | tr '[:lower:].' '[:upper:]_')
     export classes="NFSROOT $iarch $distro"
-    [ X$verbose = X1 ] && echo Classes are set to $classes
+    if [ X$verbose = X1 ] ; then
+      echo Classes are set to $classes
+    fi
 }
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 setup_ssh() {


### PR DESCRIPTION
with the shortcircuit logic at the end of the `setclasses` function, `fai-make-nfsroot` does not complete successfully when `-v` is not passed in:
> + setclasses
> + local iarch distro
> ++ chroot /srv/fai/nfsroot/jessie-amd64 dpkg --print-architecture
> ++ tr /a-z/ /A-Z/
> + iarch=AMD64
> ++ . /srv/fai/nfsroot/jessie-amd64/etc/os-release
> +++ PRETTY_NAME='Debian GNU/Linux 8 (jessie)'
> +++ NAME='Debian GNU/Linux'
> +++ VERSION_ID=8
> +++ VERSION='8 (jessie)'
> +++ ID=debian
> +++ HOME_URL=http://www.debian.org/
> +++ SUPPORT_URL=http://www.debian.org/support
> +++ BUG_REPORT_URL=https://bugs.debian.org/
> ++ echo debian debian_8
> ++ tr '[:lower:].' '[:upper:]_'
> + distro='DEBIAN DEBIAN_8'
> + export 'classes=NFSROOT AMD64 DEBIAN DEBIAN_8'
> + classes='NFSROOT AMD64 DEBIAN DEBIAN_8'
> + '[' X = X1 ']'
> + RC=1

output from `bash -x /usr/sbin/fai-make-nfsroot -f`. the formatting isn't perfect, hope the above is clear.  this commit allows the process to complete and return exit code of `0` even when `-v` is not passed in.