### PR TITLE
Better fix to detect lvm usage

### DIFF
--- a/bin/fai-diskimage
+++ b/bin/fai-diskimage
@@ -176,8 +176,8 @@ fi
 
 # currently fai-diskimage can't be used if the host contains logical volumes
 set +e
-if [ -f /sbin/lvs ]; then
-    lvs 2>&1 | grep -q 'No volume groups found'
+if [ -f /sbin/dmsetup ]; then
+    dmsetup ls 2>&1 | grep -q 'No devices found'
     if [ $? -eq 1 ]; then
 	die 9 "Currently fai-diskimage can't be run if the host uses logical volumes."
     fi


### PR DESCRIPTION
the output of lvs is not stable between debian releases, on current stretch
lvs output nothing if no logical volumes are found, which miss the grep test

instead of lvs, use dmsetup ls which ouput the same messages on both releases
(for the record an output of `dmsetup ls` on a system with LVM would be:

dmsetup ls
VolGroup00-LogVol01	(253:0)
VolGroup00-LogVol00	(253:1)

this is still a workaround until #845428 is fixed