### PR TITLE
Fix non-working documentation examples

### DIFF
--- a/doc/fai-guide.txt
+++ b/doc/fai-guide.txt
@@ -1670,7 +1670,7 @@ running system. The disk image can also be converted to qcow2 format.
 
 ----
  faiserver# export FAI_BASEFILEURL=http://fai-project.org/download/basefiles/
- faiserver# fai-diskimage -u cloud3 -S 2G -cDEBIAN,JESSIE64,AMD64,FAIBASE,GRUB_PC,CLOUD,GCE disk
+ faiserver# fai-diskimage -u cloud3 -S 2G -cDEBIAN,JESSIE64,AMD64,FAIBASE,GRUB_PC,CLOUD,GCE disk.raw
 ----
 Creates the file disk.raw for a host called cloud3, with a small set
 of software packages.
@@ -1678,7 +1678,7 @@ of software packages.
 ----
  # export FAI_BASEFILEURL=http://fai-project.org/download/basefiles/
  # cl=DEFAULT,DHCPC,DEBIAN,AMD64,FAIBASE,GRUB_PC,UBUNTU,XENIAL,XENIAL64,XORG
- # fai-diskimage -v -C -u foobar -S5G -c$cl ubuntu
+ # fai-diskimage -v -u foobar -S5G -c$cl ubuntu.qcow2
 ----
 Creates a disk image called ubuntu.qcow2 for a Ubuntu 16.04 desktop
 with hostname set to foobar.


### PR DESCRIPTION
since commit 904681273e986d459d3d6a222bd009f3a7b2e38a
the required disk type (raw, qcow2, etc) is based on the extension of the command line
disk paramater, and is required argument.

without a disk type extention the shell parameter substition in fai-diskimage
ext=${image##*.}
confuses a diks name "jessie" with an  extension and exits with:

"Unknown suffix .jessie in name of disk image."