### PR TITLE
re-add code to strip basefile name extension

### DIFF
--- a/lib/fetch-basefile
+++ b/lib/fetch-basefile
@@ -41,6 +41,7 @@ done
 flist=$(lftp -e 'cls;exit' $url 2>/dev/null)
 # create an array of all lines
 baselist=($flist)
+baselist=("${baselist[@]%%.*}")
 
 # reverse order of classes
 for c in $classes; do


### PR DESCRIPTION
the older version of the code stripped everything following the first "."
the recent change to use an array did not include this functionality.
without it the class names would need to append the trailing
extentions e.g., .tar.xz