### PR TITLE
Adding grep to match the fai-project.org keyring on the host if apt-k…

### DIFF
--- a/bin/fai-make-nfsroot
+++ b/bin/fai-make-nfsroot
@@ -465,7 +465,7 @@ upgrade_nfsroot() {
     fi
 
     # if we have the keyring on the host, install the key of the fai-project.org package repository
-    if [ -n "$(apt-key list | grep 074BCDE4)" ]; then
+    if [ -n "$(apt-key list | grep 074BCDE4)" ] || [ -n "$(apt-key list | grep '074B CDE4')" ]; then
         HOME=/root apt-key export 074BCDE4 | chroot $NFSROOT apt-key add -
     fi
 


### PR DESCRIPTION
…ey list returns a key with a space.

This is related to the bug report filed here: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=878447

On the host: Debian 9 (Stretch), when running fai-make-nfsroot, when it checks to see if the key of the fai-project.org package repository is installed on the host, it's expects the key id to not contain spaces.   However, apt-key list returns the key with spaces:

pub   rsa4096 2013-07-30 [SC]
      B11E E327 3F6B 2DEB 528C  93DA 2BF8 D9FE 074B CDE4
uid           [ unknown] Thomas Lange <lange@informatik.uni-koeln.de>
uid           [ unknown] Thomas Lange <lange@debian.org>
sub   rsa4096 2013-07-30 [E]

This pull request adds a second search for this scenario.

