### PR TITLE
Adding a note about the grub config

### DIFF
--- a/man/fai-cd.8
+++ b/man/fai-cd.8
@@ -58,6 +58,12 @@ mirror, which is created by fai-mirror. The ISO image will contain a compressed
 squashfs filesystem. This hybrid CD image can also
 be written to an USB stick using dd(1).
 
+NOTE: By default, fai-cd uses the grub file from /etc/fai/grub.cfg, which is
+designed for demo purposes.  This grub menu passes the "menu" flag to the
+FAI_FLAGS parameter, which causes a menu with various installation and 
+boot options to be displayed on each boot.  To avoid this, you must specify
+your own grub file using the -g flag, as described below.
+
 .SH OPTIONS
 .TP
 .BI \-A
@@ -165,6 +171,10 @@ option:
 Create the autodiscover boot image:
 
    # fai-cd \-JAg /etc/fai/grub.cfg.autodiscover fai-autod.iso
+
+Specify your own grub file:
+
+   # fai-cd -g /srv/fai/config/my_extras/grub.cfg -m /srv/fai/mirror /srv/fai/iso/fai-cd.iso
 
 .SH NOTES
 Additional kernel command line options can be found in the man page of


### PR DESCRIPTION
I thought it might be helpful to add some explicit notes about specifying an alternative grub file when burning CDs.  I spent quite some time trying to figure this out before I reached out and got a response from Thomas Lange about it.  I recently spoke with someone else who had been wrestling with the same issue.  