### PR TITLE
Add AllowInsecureRepositories to suppress errors...

### DIFF
--- a/bin/fai-make-nfsroot
+++ b/bin/fai-make-nfsroot
@@ -395,6 +395,7 @@ create_nfsroot() {
     cat >$NFSROOT/etc/apt/apt.conf.d/10fai <<EOF
 APT::Install-Recommends no;
 APT::Get::AllowUnauthenticated true;
+Acquire::AllowInsecureRepositories "true";
 Aptitude::CmdLine::Ignore-Trust-Violations yes;
 Acquire::Languages none;
 Acquire::Check-Valid-Until false;

--- a/lib/subroutines
+++ b/lib/subroutines
@@ -1098,6 +1098,7 @@ task_repository () {
     if [ X$FAI_ALLOW_UNSIGNED = X1 ]; then
         cat <<EOF > $FAI_ROOT/etc/apt/apt.conf.d/10fai
 APT::Get::AllowUnauthenticated "true";
+Acquire::AllowInsecureRepositories "true";
 Aptitude::CmdLine::Ignore-Trust-Violations yes;
 EOF
     else


### PR DESCRIPTION
for newer versions of APT

Since version 1.5\~beta1 of `apt` Debian have changed so that security exceptions gets an error instead of a warning if unauthenticated repositories are encountered. Ubuntu Bionic (18.04) are using 1.6~beta1 for example.

This patch will include the 'AllowInsecureRepositories' option if FAI_ALLOW_UNSIGNED=1 is used to suppress the errors and only generate warnings instead.

--
Markus