### PR TITLE
Also install apt keys in binary (.gpg) format in /etc/apt/trusted.gpg.d

### DIFF
--- a/lib/subroutines
+++ b/lib/subroutines
@@ -1106,9 +1106,12 @@ EOF
 
     # add apt keys for all classes
     for keyfile in ${classes:-}; do
-        [ ! -f $FAI/package_config/$keyfile.asc ] && continue
-        echo -n "Copying APT key from $keyfile.asc "
-        cp $FAI/package_config/$keyfile.asc $FAI_ROOT/etc/apt/trusted.gpg.d/
+        keyfile_name=""
+        [ -f $FAI/package_config/$keyfile.gpg ] && keyfile_name=$keyfile.gpg
+        [ -f $FAI/package_config/$keyfile.asc ] && keyfile_name=$keyfile.asc
+        [ -z $keyfile_name ] && continue
+        echo -n "Copying APT key from $keyfile_name "
+        cp $FAI/package_config/$keyfile_name $FAI_ROOT/etc/apt/trusted.gpg.d/
     done
 
     # mount Debian mirror via NFS if needed


### PR DESCRIPTION
This patch will copy over keys in gpg binary format from config_dir/package_config/<classname>.gpg to /etc/apt/trusted.gpg.d
This is needed for Debian 8 and other systems with apt < 1.4, which doesn't understand keys in ASCII format.
In this form of the patch, ASCII keys will take precedence over binary keys, i.e. only myclass.asc is copied if both myclass.asc and myclass.gpg exist.