### PR TITLE
fix --print-foreign-architectures parsing

### DIFF
--- a/lib/check-cross-arch
+++ b/lib/check-cross-arch
@@ -45,9 +45,15 @@ cross=1
 # debugging echo myarch: $myarch targetarch: $targetarch
 if [ $myarch = $targetarch ]; then
     cross=0
-elif [ $targetarch = $(dpkg --print-foreign-architectures) ]; then
-    cross=0
 fi
+
+for arch in $(dpkg --print-foreign-architectures)
+do
+    if [ $myarch = $arch ]; then
+        cross=0
+        break
+    fi
+done
 
 
 if [ $cross -eq 1 ]; then

--- a/lib/subroutines
+++ b/lib/subroutines
@@ -948,16 +948,21 @@ call_debootstrap() {
     # Check if we need cross architecture debootstrap
     targetarch=$(expr "$FAI_DEBOOTSTRAP_OPTS" : '.*--arch=\([^[:space:]]*\)' || true)
     hostarch1=$(dpkg --print-architecture)
-    hostarch2=$(dpkg --print-foreign-architectures)
 
     _debootstrap=qemu-debootstrap
     if [ -z "$targetarch" ]; then
 	_debootstrap=debootstrap
     else
-	if [ $targetarch = $hostarch1 -o $targetarch = $hostarch2 ]; then
+	if [ $targetarch = $hostarch1 ]; then
 	_debootstrap=debootstrap
 	fi
-    fi
+    for arch in $(dpkg --print-foreign-architectures)
+    do
+        if [ $targetarch = $arch ]; then
+	        _debootstrap=debootstrap
+            break
+        fi
+    done
     if [ $_debootstrap = "qemu-debootstrap" ]; then
 	if ! type -P $_debootstrap >/dev/null; then
 	    die 1 "qemu-debootstrap not found. Please install the package qemu-user-static."


### PR DESCRIPTION
The amount foreign archs may be 0, 1, or more. Currently the cross-arch
parsing fails if no foreign archs or more than 1. Use a fore loop to
compare.