### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fai (5.7.2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 01:05:15 +0100
+
 fai (5.7.1) unstable; urgency=low
 
   [ Thomas Lange ]

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Uploaders: Michael Prokop <mika@debian.org>
 Standards-Version: 4.2.1
 Build-Depends-Indep: asciidoc-dblatex, w3m, dblatex, docbook-xsl, libparse-recdescent-perl
 Build-Depends: debhelper (>= 7), libgraph-perl
-Vcs-Git: git://github.com/faiproject/fai.git
+Vcs-Git: https://github.com/faiproject/fai.git
 Vcs-Browser: https://github.com/faiproject/fai
 Homepage: https://fai-project.org
 


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
