### PR TITLE
install_packages changed warn message

### DIFF
--- a/bin/install_packages
+++ b/bin/install_packages
@@ -282,7 +282,7 @@ sub readconfig {
 
     if (/^PACKAGES\s+(\S+)\s*/) {
       ($type,$cllist) = ($1,$');
-      warn "WARNING: Unknow action $type after PACKAGES\n" unless defined $command{$type};
+      warn "WARNING: Unknown action $type after PACKAGES\n" unless defined $command{$type};
       # by default no classes are listed after this command so doit
       $doit = 1;
       if ($cllist) {


### PR DESCRIPTION
Fixed warning message for unknown action after packges.
Changed inside of the message "Unknow" to "Unknown"