### PR TITLE
add newline to kernel parameters message

### DIFF
--- a/lib/subroutines
+++ b/lib/subroutines
@@ -792,7 +792,7 @@ eval_cmdline() {
     echo "Kernel currently running: "
     uname -rsmo
     cmdline="$(</proc/cmdline)"
-    echo -n "Kernel parameters: $cmdline"
+    echo "Kernel parameters: $cmdline"
     for word in $cmdline; do
 	if echo "$word" | egrep -q '^[a-zA-Z0-9_]+=' ; then
             eval "export $word"


### PR DESCRIPTION
When commit 6d50cbe was made, the echo command from the kernel parameters message was changed from echo to echo -n, suppressing the newline at the end of the string. I believe this has caused a minor malfunction in the printing of messages during the installation, where the kernel parameters line has the next line (Reading /tmp/boot/fai.log) appended directly to the end.

One script we have configured in FAI reads and parses the kernel parameters line, and this change causes the parameter at the end to be malformed with the string 'Reading' appended. Changing the 'echo -n' back to 'echo' fixes the problem in my tests. I would request this be changed in the main code branch as I believe the current behavior is undesirable.

Current behavior:
`Kernel parameters: foo bar bazReading /tmp/fai/boot.log`

Behavior after change:
`Kernel parameters: foo bar baz`
`Reading /tmp/fai/boot.log`

Please let me know if you have any questions or comments.