### PR TITLE
Foreign architecture may not be defined.

### DIFF
--- a/bin/fai-make-nfsroot
+++ b/bin/fai-make-nfsroot
@@ -263,6 +263,9 @@ call_debootstrap() {
     targetarch=$(echo "$(expr "$FAI_DEBOOTSTRAP_OPTS" : '.*--arch[=[:space:]]\([^[:space:]]*\)' || true)" | tail -n 1)
     hostarch1=$(dpkg --print-architecture)
     hostarch2=$(dpkg --print-foreign-architectures)
+    if [ -z "$hostarch2" ]; then
+        hostarch2=$hostarch1
+    fi
 
     _debootstrap=qemu-debootstrap
     if [ -z "$targetarch" ]; then


### PR DESCRIPTION
Under som circumstances dpkg --print-foreign-architectures returns an empty string. In that case assume that it is the same as dpkg --print-architecture.