### PR TITLE
Patch Commands.pm

### DIFF
--- a/lib/setup-storage/Commands.pm
+++ b/lib/setup-storage/Commands.pm
@@ -337,6 +337,8 @@ sub build_btrfs_commands {
     }
   }
 
+  my %mkfs_done;
+
   foreach my $config (keys %FAI::configs) { # loop through all configs
     next unless ($config eq "BTRFS");
 
@@ -365,16 +367,23 @@ sub build_btrfs_commands {
       $pre_req = "exist_" . $devs[0];
     }
     # creates the BTRFS volume/RAID
-    if ($raidlevel eq 'single') {
-          &FAI::push_command("mkfs.btrfs -d single $createopts ". join(" ",@devs),
-                             "$pre_req",
-                             "btrfs_built_raid_$id");
-
-        } else {
-          &FAI::push_command("mkfs.btrfs -d raid$raidlevel $createopts ". join(" ",@devs),
-                             "$pre_req",
-                             "btrfs_built_raid_$id");
-        }
+     if ($raidlevel eq 'single') {     
+      if (exists $mkfs_done{join(" ", @devs)}) {     
+        &FAI::push_command("true",     
+          "$pre_req",     
+          "btrfs_built_raid_$id");     
+      } else {     
+        print "Adding mkfs command for '", join(", ", @devs), "'.\n";     
+        &FAI::push_command("mkfs.btrfs -d single $createopts ".join(" ",@devs),     
+          "$pre_req",     
+          "btrfs_built_raid_$id");     
+          $mkfs_done{join(" ", @devs)} = '1';     
+      }     
+    } else {     
+      &FAI::push_command("mkfs.btrfs -d raid$raidlevel $createopts ".join(" ",@devs),     
+        "$pre_req",     
+        "btrfs_built_raid_$id");     
+    }
 
     # initial mount, required to create the initial subvolume
     &FAI::push_command("mount $devs[0] /mnt",


### PR DESCRIPTION
Currently the `build_btrfs_commands` function appends a `mkfs.btrfs` to the command queue prior to the creation of every subvolume when iterating through a `disk_config` file. The result of this is that only the last subvolume created in the queue exists after `setup-storage` has run.

I am not a perl programmer. This patch aims to provide a small and simple fix that allows BTRFS subvolumes to be created properly. This patch has been tested.