### PR TITLE
Fai guide

### DIFF
--- a/doc/fai-guide.txt
+++ b/doc/fai-guide.txt
@@ -1672,11 +1672,17 @@ additional packages into the nfsroot.
 You can easily create an installation CD (or USB stick) of your
 network installation setup. This will perform the same installation
 and configuration from CD without the need of the install server.
-Therefore you need to create a partitial mirror of all Debian packages
+Therefore you need to create a partial mirror of all Debian packages
 needed for your FAI classes (using `fai-mirror(1)`). Then the command
 `fai-cd(8)` will put this mirror, the nfsroot and the config space
 onto a bootable CD. That's it!
 
+To easily create the installation CD, you can use the following command 
+(for more tuning details see `fai-cd(8)`):
+
+----
+ faiserver# fai-cd -m <partialMirrorDir> faiserver-cd.iso
+----
 
 This installation CD contains all data needed for the
 installation. The command `fai-cd(8)` puts the nfsroot, the
@@ -1691,7 +1697,7 @@ stick by just writing the content of the ISO file to your USB stick
 (here the stick is _/dev/sdf_).
 
 ----
- faiserver# dd if=fai-cd.iso of=/dev/sdf bs=1M
+ faiserver# dd if=faiserver-cd.iso of=/dev/sdf bs=1M
 ----
 
 This is no live CD of the install server.

--- a/doc/setup-storage-overview.txt
+++ b/doc/setup-storage-overview.txt
@@ -34,8 +34,8 @@ Sizes.pm   compute_partition_sizes
 ┌---------------|
 |		|
 Commands.pm build_disk_commands
-|	    buiild_raid_commands
-|	    buiild_cryptsetup_commands
+|	    build_raid_commands
+|	    build_cryptsetup_commands
 |	    order_commands
 |		|
 └---------------|

--- a/man/fai-cd.8
+++ b/man/fai-cd.8
@@ -183,6 +183,12 @@ Create the autodiscover boot image:
 
    # fai-cd \-JAg /etc/fai/grub.cfg.autodiscover fai-autod.iso
 
+Create a minimalistic compressed network boot ISO image (~350MB) without partial mirror and basefiles:
+
+   # fai-cd -BMJe fai-cd.iso
+
+This ISO image can even be further reduced in size using the -s flag to fai-make-nfsroot(8).
+
 Specify your own grub file:
 
    # fai-cd -g /srv/fai/config/my_extras/grub.cfg -m /srv/fai/mirror /srv/fai/iso/fai-cd.iso
@@ -199,6 +205,8 @@ it to another directories, before calling fai-cd.
 .BR fai\-mirror(1)
 
 .BR mksquashfs(1)
+
+.BR fai-make-nfsroot(8)
 .SH FILES
 .PD 0
 .TP

--- a/man/setup-storage.8
+++ b/man/setup-storage.8
@@ -267,8 +267,8 @@ primary -       4096-   -       -
 
 disk_config lvm
 vg      my_pv   sda2
-my_pv-_swap     swap    2048    swap    sw
-my_pv-_root     /       2048    ext3    rw
+my_pv_swap     swap    2048    swap    sw
+my_pv_root     /       2048    ext3    rw
 .sp
 .fi
 .PP


### PR DESCRIPTION
chg: typo, detail how to use fai-cd and clarify usage for minimalistic ISO image size.