### PR TITLE
#918187 - Add error checking for hooks to stop the installation

### DIFF
--- a/bin/fai-mirror
+++ b/bin/fai-mirror
@@ -388,7 +388,7 @@ Origin: fai-mirror
 EOF
 
 # maybe using reprepro pulls it's possible to move instead of copy the packages
-    if ls "$archivedir/*~bpo[0-9]*+[0-9-]*_*.deb" >/dev/null 2>&1; then
+    if ls $archivedir/*~bpo[0-9]*+[0-9-]*_*.deb >/dev/null 2>&1; then
         reprepro -b $mirrordir includedeb $bponame $archivedir/*~bpo[0-9]*+[0-9-]*_*.deb
         rm -f $archivedir/*~bpo[0-9]*+[0-9-]*_*.deb
     fi

--- a/lib/subroutines
+++ b/lib/subroutines
@@ -285,18 +285,18 @@ call_hook() {
             sendmon "HOOK $hook.$cl.sh"
             # source this hook
             . $hfile.sh $dflag "$@"
-            task_error=$?
-            check_status $hook.$cl.sh $task_error
-            [ $task_error -gt $STOP_ON_ERROR ] && stop_fai_installation
+            hook_error=$?
+            check_status $hook.$cl.sh $hook_error
+            [ $hook_error -gt $STOP_ON_ERROR ] && stop_fai_installation
         fi
         if [ -x $hfile ]; then
             echo "Calling hook: $hook.$cl"
             sendmon "HOOK $hook.$cl"
             # execute the hook
             $hfile $dflag "$@"
-            task_error=$?
-            check_status $hook.$cl $task_error
-            [ $task_error -gt $STOP_ON_ERROR ] && stop_fai_installation
+            hook_error=$?
+            check_status $hook.$cl $hook_error
+            [ $hook_error -gt $STOP_ON_ERROR ] && stop_fai_installation
         fi
         # deprecated
 	if [ -x $hfile.source ]; then

--- a/lib/subroutines
+++ b/lib/subroutines
@@ -285,14 +285,18 @@ call_hook() {
             sendmon "HOOK $hook.$cl.sh"
             # source this hook
             . $hfile.sh $dflag "$@"
-            check_status $hook.$cl.sh $?
+            task_error=$?
+            check_status $hook.$cl.sh $task_error
+            [ $task_error -gt $STOP_ON_ERROR ] && stop_fai_installation
         fi
         if [ -x $hfile ]; then
             echo "Calling hook: $hook.$cl"
             sendmon "HOOK $hook.$cl"
             # execute the hook
             $hfile $dflag "$@"
-            check_status $hook.$cl $?
+            task_error=$?
+            check_status $hook.$cl $task_error
+            [ $task_error -gt $STOP_ON_ERROR ] && stop_fai_installation
         fi
         # deprecated
 	if [ -x $hfile.source ]; then


### PR DESCRIPTION
Hi Thomas,

I've had encounters with bug #918187 where a hook will fail yet it's subsequent task will run (even with error codes over `STOP_ON_ERROR`). I believe that given the nature of hooks, the installation should halt on a failed hook (with a code over `STOP_ON_ERROR`) because the following task will either crash the installation or cause unexpected behavior.

Thanks,
Donovan Keohane