### PR TITLE
add ubuntu generic kernel and other dependencies for successfull ubuntu nfsroot

### DIFF
--- a/conf/NFSROOT
+++ b/conf/NFSROOT
@@ -77,3 +77,13 @@ fdisk gpg
 
 PACKAGES install-norec DEBIAN_11
 fdisk gpg
+
+PACKAGES install UBUNTU
+debootstrap
+fdisk gpg
+sysvinit-core-
+systemd-sysv
+linux-image-generic
+git
+ifupdown
+screen


### PR DESCRIPTION
ubuntu doesn't have linux-image-amd64 and sysvinit-core.