### PR TITLE
Ensure there are backported packages before calling reprepro

### DIFF
--- a/bin/fai-mirror
+++ b/bin/fai-mirror
@@ -388,8 +388,10 @@ Origin: fai-mirror
 EOF
 
 # maybe using reprepro pulls it's possible to move instead of copy the packages
-     reprepro -b $mirrordir includedeb $bponame $archivedir/*~bpo[0-9]*+[0-9-]*_*.deb
-     rm -f $archivedir/*~bpo[0-9]*+[0-9-]*_*.deb
+    if ls "$archivedir/*~bpo[0-9]*+[0-9-]*_*.deb" >/dev/null 2>&1; then
+        reprepro -b $mirrordir includedeb $bponame $archivedir/*~bpo[0-9]*+[0-9-]*_*.deb
+        rm -f $archivedir/*~bpo[0-9]*+[0-9-]*_*.deb
+    fi
 fi
 
 # allow package without the .deb suffix. At least they must start with a char and contain an underscore or hyphen


### PR DESCRIPTION
I have had some problems with the glob in the reprepro call failing

```bash
reprepro -b $mirrordir includedeb $bponame $archivedir/*~bpo[0-9]*+[0-9-]*_*.deb
```

This PR just adds a safety check to ensure that the glob matches before calling reprepro.