### PR TITLE
Prefer 'grep -E' over 'egrep'

### DIFF
--- a/bin/fai
+++ b/bin/fai
@@ -254,7 +254,7 @@ if [ X$FAI_ACTION = Xdirinstall ]; then
 
     # check if target directory is mounted with bad options
     fs=$(df -P $FAI_ROOT | tail -1 | awk '{print $6}')
-    if mount | grep "on $fs " |  awk '{print $6}' | egrep -q "nosuid|nodev"; then
+    if mount | grep "on $fs " |  awk '{print $6}' | grep -E -q "nosuid|nodev"; then
         fdie 5 "Target directory is mounted using nosuid or nodev. Aborting" >&2
     fi
     unset fs

--- a/bin/fai-debconf
+++ b/bin/fai-debconf
@@ -37,7 +37,7 @@ call_conf() {
     for class in $classes ; do
         [ -f $class ] && add_data $class
         if [ -d $class ]; then
-           for f in $(ls $class/* | egrep '^[[:alnum:]/_.-]+$') ; do
+           for f in $(ls $class/* | grep -E '^[[:alnum:]/_.-]+$') ; do
                [ -f $f ] && add_data $f
            done
         fi

--- a/bin/fai-make-nfsroot
+++ b/bin/fai-make-nfsroot
@@ -72,7 +72,7 @@ check_nfsroot() {
     $ROOTCMD dpkg-query -W -f='${Package;-18} ${Version}\n' fai-client fai-nfsroot fai-setup-storage dracut-network dracut dracut-live dracut-squash 2>/dev/null
 
     # check if all important packages are installed
-    n=$($ROOTCMD dpkg-query -l fai-client fai-nfsroot fai-setup-storage dracut-network dracut 2>/dev/null|egrep ^ii |wc -l)
+    n=$($ROOTCMD dpkg-query -l fai-client fai-nfsroot fai-setup-storage dracut-network dracut 2>/dev/null|grep -E ^ii |wc -l)
     if [ $n -ne 5 ]; then
 	echo "ERROR: Some essential pacakges are missing."
 	bad_exit
@@ -80,7 +80,7 @@ check_nfsroot() {
 
     local files=$(ls $NFSROOT/boot/initrd* 2>/dev/null)
     [ -z "$files" ] && die 1 "No initrd installed."
-    egrep -q "^ERROR: |^E: Sub-process |^dpkg: error processing |^dpkg: dependency problems" /var/log/fai/fai-make-nfsroot.log && bad_exit
+    grep -E -q "^ERROR: |^E: Sub-process |^dpkg: error processing |^dpkg: dependency problems" /var/log/fai/fai-make-nfsroot.log && bad_exit
     return 0
 }
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -253,7 +253,7 @@ call_debootstrap() {
 
     # check if NFSROOT directory is mounted with bad options
     fs=$(df -P $NFSROOT | tail -1 | awk '{print $6}')
-    if mount | grep "on $fs " |  awk '{print $6}' | egrep -q "nosuid|nodev"; then
+    if mount | grep "on $fs " |  awk '{print $6}' | grep -E -q "nosuid|nodev"; then
         die 1 "NFSROOT directory $NFSROOT is mounted using nosuid or nodev. Aborting"
     fi
     local dversion=$(dpkg-query -Wf '${Version}\n' debootstrap)

--- a/bin/fai-mirror
+++ b/bin/fai-mirror
@@ -181,7 +181,7 @@ set-classes() {
 
     set +e
     # all available file names are classes
-    classes=$(cd $FAI_CONFIGDIR/package_config; ls -1 | egrep -i "^[a-zA-Z0-9_-]+$")
+    classes=$(cd $FAI_CONFIGDIR/package_config; ls -1 | grep -E -i "^[a-zA-Z0-9_-]+$")
     addclasses=$(grep -h PACKAGES $FAI_CONFIGDIR/package_config/* | sed -e 's/#.*//' | awk '{printf $3"\n"$4"\n"$5"\n"$6"\n"}')
     export classes=$(echo -e "$classes\n$addclasses\n" | sort | uniq)
     [ -n "$exclasses" ] && excludeclass $exclasses
@@ -296,7 +296,7 @@ command -v reprepro >&/dev/null || die 8 "reprepro not found. Please install the
 # use first argument if given, use variable mirrordir if not argument was given
 [ -n "$1" ] && mirrordir=$1
 [ -z "$mirrordir" ] && die 2 "Please give the absolute path to the mirror."
-{ echo $mirrordir | egrep -q '^/'; } || die 4 "Mirrordir must start with a slash /."
+{ echo $mirrordir | grep -E -q '^/'; } || die 4 "Mirrordir must start with a slash /."
 
 [ -d $FAI_CONFIGDIR/package_config ] || die 6 "Can't find package config files in $FAI_CONFIGDIR."
 
@@ -373,7 +373,7 @@ Origin: fai-mirror
 EOF
 
 # check if backports are used
-bponame=$(egrep '^deb ' $aptcache/etc/apt/sources.list | grep -P -o '\S+-backports')
+bponame=$(grep -E '^deb ' $aptcache/etc/apt/sources.list | grep -P -o '\S+-backports')
 # add entry for backports
 if [ -n "$bponame" ]; then
      cat >> $mirrordir/conf/distributions <<EOF

--- a/lib/check-cross-arch
+++ b/lib/check-cross-arch
@@ -61,7 +61,7 @@ if [ $cross -eq 1 ]; then
      [ X$verbose = X1 ] && echo "Using qemu-$targetarch-static for cross architecture chroot."
 
      # if the flag F is set, we do not need the static executable inside $target
-     if egrep -q --color '^flags: .*F.*' /proc/sys/fs/binfmt_misc/qemu-$targetarch; then
+     if grep -E -q --color '^flags: .*F.*' /proc/sys/fs/binfmt_misc/qemu-$targetarch; then
 	 :
      else
 	 cp /usr/bin/qemu-$targetarch-static $target/usr/bin

--- a/lib/fai-disk-info
+++ b/lib/fai-disk-info
@@ -30,4 +30,4 @@ stick=${stick%%[[:digit:]]*}
 
 
 # echo a space separated list of devices and their block size
-( egrep 'md[0-9]{3,}$' /proc/partitions; egrep ' etherd/e[[:digit:]]+\.[[:digit:]]+\b| i2o/hd.+\b| cciss/c[[:digit:]]+d[[:digit:]]+\b| ida/c[[:digit:]]+d[[:digit:]]+\b| rd/c[[:digit:]]+d[[:digit:]]+\b| fio.\b| hd.\b| sd[a-z]{1,2}\b|/disc\b| vd.\b| xvd.\b| nvme[[:digit:]]+n1$| mmcblk[[:digit:]]+$' /proc/partitions ) | checkdisk
+( grep -E 'md[0-9]{3,}$' /proc/partitions; grep -E ' etherd/e[[:digit:]]+\.[[:digit:]]+\b| i2o/hd.+\b| cciss/c[[:digit:]]+d[[:digit:]]+\b| ida/c[[:digit:]]+d[[:digit:]]+\b| rd/c[[:digit:]]+d[[:digit:]]+\b| fio.\b| hd.\b| sd[a-z]{1,2}\b|/disc\b| vd.\b| xvd.\b| nvme[[:digit:]]+n1$| mmcblk[[:digit:]]+$' /proc/partitions ) | checkdisk

--- a/lib/get-boot-info
+++ b/lib/get-boot-info
@@ -38,7 +38,7 @@ netdevice_info() {
     # if not defined, use boot messages to determine network devices
     [ -n "$netdevices" ] || netdevices=$netdevices_up
 
-    netdevices_all=$(ip link | grep "^[1-9]" | cut -d : -f 2 | cut -d ' ' -f 2 | egrep "^eth|^en")
+    netdevices_all=$(ip link | grep "^[1-9]" | cut -d : -f 2 | cut -d ' ' -f 2 | grep -E "^eth|^en")
     netdevices_all=$(for dev in $netdevices_all; do echo $dev; done| sort | uniq| tr '\n' ' ')
 }
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/lib/get-config-dir-git
+++ b/lib/get-config-dir-git
@@ -41,7 +41,7 @@ _git_checkout() {
 }
 
 if [ -d "$GIT_DIR" ]; then
-    if [ `git remote show -n origin | egrep -m1 -o '[^[:space:]]+://.+'` == "$giturl" ]; then
+    if [ `git remote show -n origin | grep -E -m1 -o '[^[:space:]]+://.+'` == "$giturl" ]; then
         echo "Updating git copy in $FAI"
         git fetch
         task_error 881 $?

--- a/lib/subroutines
+++ b/lib/subroutines
@@ -141,7 +141,7 @@ umount_target() {
     if [ "$target" != '/' ]; then
 	# do not umount during softupdate
 	umount $FAI_ROOT/proc $FAI_ROOT/sys $FAI_ROOT/dev/pts $FAI_ROOT/dev 2>/dev/null
-	for dir in $(mount | grep $target | egrep -v "media/mirror|tmpfs"| awk '{print $3}' | sort -r); do
+	for dir in $(mount | grep $target | grep -E -v "media/mirror|tmpfs"| awk '{print $3}' | sort -r); do
             mountpoint -q $dir && umount $dir
 	done
     fi
@@ -750,7 +750,7 @@ task_softupdate() {
 
 catnc() {
     # cat but no comment lines
-    egrep -v "^#" $@
+    grep -E -v "^#" $@
 }
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### BEGIN SUBROUTINE INFO
@@ -775,7 +775,7 @@ eval_cmdline() {
     cmdline="$(</proc/cmdline)"
     echo "Kernel parameters: $cmdline"
     for word in $cmdline; do
-	if echo "$word" | egrep -q '^[a-zA-Z0-9_]+=' ; then
+	if echo "$word" | grep -E -q '^[a-zA-Z0-9_]+=' ; then
             eval "export $word"
 	fi
     done
@@ -1143,7 +1143,7 @@ task_instsoft() {
         task_error 471 $?
     fi
     # This almost indicates an error
-    egrep "^E:" $LOGDIR/software.log && task_error 472
+    grep -E "^E:" $LOGDIR/software.log && task_error 472
     grep "Couldn't find any package whose name or description matched" $LOGDIR/software.log && task_error 321
     grep -q "E: Sub-process /usr/bin/dpkg returned an error code" $LOGDIR/software.log && task_error 620
 }
@@ -1153,12 +1153,12 @@ task_finish() {
     mkramdisk -au # umount ramdisk
     if [ $do_init_tasks -eq 1 ] ; then
         # show some local information
-        df -PTh | egrep ':|^/|^Filesystem'
+        df -PTh | grep -E ':|^/|^Filesystem'
         # show rx and tx bytes of network device
         grep . /sys/class/net/*/statistics/*x_bytes | perl -ane 'm#/sys/class/net/(.+)/statistics/(.+):(\d+)# && ($3) && ($1 ne lo) && printf "%s %s %.2f Mbytes\n",$1,$2,$3/1000000 '
         swapoff -a
     else
-        df -PTh | egrep "^Filesystem|$target"
+        df -PTh | grep -E "^Filesystem|$target"
     fi
 
     # undo fake of all programs made by fai
@@ -1179,7 +1179,7 @@ task_chboot() {
     local hostname
     read hostname < /proc/sys/kernel/hostname
     local ipaddr=$(grep IPADDR $LOGDIR/boot.log | cut -d= -f2 | sed "s/'//g")
-    local nexttest=$(egrep -s ^NEXTTEST= $LOGDIR/test.log | cut -d= -f2)
+    local nexttest=$(grep -E -s ^NEXTTEST= $LOGDIR/test.log | cut -d= -f2)
 
     case "$FAI_LOGPROTO" in
         ftp) remotesh=ssh ;;

--- a/lib/task_inventory
+++ b/lib/task_inventory
@@ -15,7 +15,7 @@ inventory() {
     udevadm trigger
 
     cd /sys/class/dmi/id
-    grep . {board_,bios_,product_}* 2>/dev/null| sed -e 's/:/: /'| egrep -iv 'board_version|System Product Name|System Version|System Serial Number|123456789|To Be Filled|: Not |N/A|:[[:blank:]]+$'
+    grep . {board_,bios_,product_}* 2>/dev/null| sed -e 's/:/: /'| grep -E -iv 'board_version|System Product Name|System Version|System Serial Number|123456789|To Be Filled|: Not |N/A|:[[:blank:]]+$'
 
     lscpu | grep 'Hypervisor vendor:'
 
@@ -55,7 +55,7 @@ inventory() {
 	    cap=$(blockdev --getsize64 /dev/$dev | numfmt --to=iec | sed -e 's/\(.\)$/ \1/')
 	    cap="[$cap]"
 	fi
-	model=$(smartctl -i /dev/$dev | egrep 'Product:|Device Model:|Model Number:'|sed -e 's/^.*://' -e 's/^ *//')
+	model=$(smartctl -i /dev/$dev | grep -E 'Product:|Device Model:|Model Number:'|sed -e 's/^.*://' -e 's/^ *//')
 	echo "disk$d: $dev $cap $model"
 	(( d++ ))
     done

--- a/lib/task_sysinfo
+++ b/lib/task_sysinfo
@@ -11,7 +11,7 @@ echo Showing system information.
 
 # too much details [ -x "$(which dmidecode)" ] && dmidecode
 cd /sys/class/dmi/id
-grep . {board_,bios_,product_}* 2>/dev/null| sed -e 's/:/: /'| egrep -iv '123456789|To Be Filled|: Not |N/A|:[[:blank:]]+$'
+grep . {board_,bios_,product_}* 2>/dev/null| sed -e 's/:/: /'| grep -E -iv '123456789|To Be Filled|: Not |N/A|:[[:blank:]]+$'
 cd - >/dev/null
 
 if command -v lshw >&/dev/null; then
@@ -69,7 +69,7 @@ fi
 for device in /dev/sd?; do
     [ -b "$device" ] || continue # make sure device exists and is valid block device
     [ `stat -c %G $device` = "disk" ] || continue
-    hdparm -I $device | egrep -v '^$' | head -5 | sed -e 's/^[[:blank:]]*//'
+    hdparm -I $device | grep -E -v '^$' | head -5 | sed -e 's/^[[:blank:]]*//'
 done
 
 # pretty print disks by id and device names
@@ -106,7 +106,7 @@ btrfs fi show
 fai-mount-disk -f
 [ -f $target/etc/fstab ] && cp -p $target/etc/fstab $LOGDIR
 
-df -PTh | egrep ':|^/|^Filesystem'
+df -PTh | grep -E ':|^/|^Filesystem'
 # - - - - - - - - - - -
 save_dmesg
 fai-savelog -r


### PR DESCRIPTION
Hi Thomas,

The use of both 'fgrep' and 'egrep' have been deprecated, [see here](https://www.gnu.org/software/grep/manual/grep.html#grep-Programs).
This pull request migrates over to the newer standard and increases portability.