### PR TITLE
initialize final_exit_code variable

### DIFF
--- a/bin/fai
+++ b/bin/fai
@@ -40,6 +40,7 @@ export romountopt=${romountopt:-"-o async,noatime,nolock,ro,actimeo=1800"}
 export faimond=0
 export renewclass=0
 export task_error=0 # tasks can set this variable to indicate an error
+final_exit_code=0
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 fdie() {


### PR DESCRIPTION
since it is uninitialized, when there are no errors in the install itself `$final_exit_code` is unset at the end of the `/usr/sbin/fai` run:
```
    355 [ -L "/var/run/fai/current_config" ] && rm -f "/var/run/fai/current_config"
    356 
    357 exit $final_exit_code
```

this means that the exit status is that of the last command executed.  in the case of concurrent installs this results in spurious failures as the `-L` test fails for all but the first.