### PR TITLE
Add missing depency procps

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -40,7 +40,7 @@ Description: Documentation for FAI
 
 Package: fai-server
 Architecture: all
-Depends: fai-client, e2fsprogs, debootstrap, xz-utils, ${misc:Depends}
+Depends: fai-client, e2fsprogs, debootstrap, xz-utils, procps, ${misc:Depends}
 Recommends: nfs-kernel-server, isc-dhcp-server, tftpd-hpa | atftpd, openssh-server, openssh-client, openbsd-inetd | inet-superserver, libproc-daemon-perl, dosfstools, mtools
 Suggests: debmirror, reprepro, xorriso, squashfs-tools, binutils, grub2, perl-tk, qemu-utils, fai-setup-storage
 Description: Fully Automatic Installation server package


### PR DESCRIPTION
FAI uses the pgrep command in a couple of place but does not declare a dependency to its procps package.
This means than in some minimal environments like the debian container image, where only Essentials packages are installed procps is missing for fai, causing some minor bugs in fai-disk-image (wrong error reporting at the end of the build)