### PR TITLE
Allow . characters in the name of base images

### DIFF
--- a/lib/fetch-basefile
+++ b/lib/fetch-basefile
@@ -38,8 +38,8 @@ while getopts m opt ; do
 done
 #shift $((OPTIND - 1))
 
-# get list of all files at URL
-flist=$(lftp -e 'cls;exit' $url 2>/dev/null)
+# get list of *.tar* files at URL
+flist=$(lftp -e 'cls *.tar*;exit' "$url" 2>/dev/null)
 # create an array of all lines
 baselist=($flist)
 
@@ -51,7 +51,7 @@ done
 # now search for each class, if a basename matches
 for c in $revclasses; do
     for f in "${baselist[@]}"; do
-	base=${f%%.*}
+	base=${f%%.tar*}
 	if [ "$c" = "$base" ]; then
             found=1
             [ $mount = 1 ] && mount_ramdisk


### PR DESCRIPTION
When considering the candidate base images at $FAI_BASEFILEURL, allow
the image filenames to contain a '.' character that is not necessarily a
delimiter for the file extension.  With this change, one could, for
example, set

FAI_BASEFILEURL=https://cloud-images.ubuntu.com/releases/server/focal/release/

and define "ubuntu-20.04-server-cloudimg-amd64-root" as one of the
classes, which would cause FAI to unpack an official Ubuntu cloud image
as the base for an installation.