### PR TITLE
fai-make-nfsroot.8: Added info about LSB namespaces when using nfsroot-hooks

### DIFF
--- a/man/fai-make-nfsroot.8
+++ b/man/fai-make-nfsroot.8
@@ -119,7 +119,7 @@ The configuration file for fai-make-nfsroot.
 .PD 0
 .TP
 .FN /etc/fai/nfsroot-hooks/
-Directory containing shell scripts to be sourced at the end of fai-make-nfsroot for additional configuration of the nfsroot. Can be changed with NFSROOT_HOOKS.
+Directory containing shell scripts (using LSB namespaces) to be sourced at the end of fai-make-nfsroot for additional configuration of the nfsroot. Can be changed with NFSROOT_HOOKS.
 .PD 0
 .TP
 .FN /etc/fai/apt/sources.list


### PR DESCRIPTION
I was scratching my head why my script was not being able to run which was named "purge-kernel_ramdisk.sh".

Looking at the source code for fai-make-nfsroot I found that the scripts are being parsed using `run-parts --lsbsysinit --list "$NFSROOT_HOOKS"` which means LSB namespaces is only allowed. Renaming "purge-kernel_ramdisk.sh" to "remove-kernel_ramdisk" did not work then I tried "remove-kernel-ramdisk" and that finally worked. So the naming that seems to be allowed is [-a-z0-9].