### PR TITLE
Add a list of all bootable devices to setup-storage

### DIFF
--- a/bin/setup-storage
+++ b/bin/setup-storage
@@ -258,9 +258,22 @@ $FAI::debug and print "$_=\${$_:-$FAI::disk_var{$_}}\n"
   foreach (keys %FAI::disk_var);
 
 if ($FAI::no_dry_run) {
+  # List all bootable devices. Can be used by later tasks to install a
+  # boot loader. Using Variable PHYSICAL_BOOT_DEVICES.
+  my @boot_devices;
+  foreach (keys %FAI::configs) {
+    $_ =~ /PHY_(.+)/;
+    if ( $1 && defined $FAI::configs{$_}{'bootable'}
+      &&  $FAI::configs{$_}{'bootable'} > 0 )  {
+      push @boot_devices, $1;
+    }
+  }
+  @boot_devices = sort @boot_devices;
+
   open(DISK_VAR, ">$FAI::DATADIR/disk_var.sh")
     or die "Unable to write to file $FAI::DATADIR/disk_var.sh\n";
   print DISK_VAR "$_=\${$_:-$FAI::disk_var{$_}}\n" foreach (keys %FAI::disk_var);
+  print DISK_VAR "PHYSICAL_BOOT_DEVICES=\"", join(" ", @boot_devices), "\"\n";
   close DISK_VAR;
 
   if ($opt_y) {
@@ -279,6 +292,9 @@ if ($FAI::no_dry_run) {
 	print DISK_YML "$_: $FAI::disk_var{$_}\n";
       }
     }
+    print DISK_YML "PHYSICAL_BOOT_DEVICES:\n";
+    my $a = join("\n  - ", @boot_devices);
+    print DISK_YML "  - $a\n";
     close DISK_YML;
   }
 }

--- a/man/setup-storage.8
+++ b/man/setup-storage.8
@@ -142,10 +142,20 @@ is generated. This file defines the following variables, if not yet set:
 .IR SWAPLIST ,
 .IR ROOT_PARTITION ,
 .IR BOOT_PARTITION
-(which is only set in case this resides on a disk drive), and
-.IR BOOT_DEVICE .
-The latter two describe the partition and disk/RAID/LVM device hosting the mount
+(which is only set in case this resides on a disk drive),
+.IR BOOT_DEVICE
+and
+.IR PHYSICAL_BOOT_DEVICES
+(which contains the list of all physical devices having a bootable partition).
+Both
+.IR BOOT_PARTITION
+and
+.IR BOOT_DEVICE
+describe the partition and disk/RAID/LVM device hosting the mount
 point for /boot. If /boot has no extra mount point, / is used instead.
+.IR PHYSICAL_BOOT_DEVICES
+can be used to determine where a bootloader should be installed (this is useful
+if / is on a LVM or RAID device).
 You may source $LOGDIR/disk_var.sh to get the variables set.
 The example config space shipped with FAI sources this file in
 scripts/GRUB_PC/10-setup.


### PR DESCRIPTION
This patch adds the PHYSICAL_BOOT_DEVICES variable to
disk_vars.sh (and YAML) which contains the list of all devices having
a bootable flagged partition.

This is useful to install a bootloader if setup-storage is used as a
stand-alone tool and / is on a RAID or LVM device.

Signed-off-by: Sébastien Gross <seb•ɑƬ•chezwam•ɖɵʈ•org>