### PR TITLE
Support aborting installation based on hook exit codes

### DIFF
--- a/bin/fai
+++ b/bin/fai
@@ -37,6 +37,8 @@ stamp=/var/run/fai/FAI_INSTALLATION_IN_PROGRESS
 export romountopt=${romountopt:-"-o async,noatime,nolock,ro,actimeo=1800"}
 
 [ -n "$STOP_ON_ERROR" ] || export STOP_ON_ERROR=700
+# By default, don't stop on any exit codes (POSIX limits error codes to 0-255)
+[ -n "$STOP_ON_HOOK_ERROR" ] || export STOP_ON_HOOK_ERROR=256
 export faimond=0
 export renewclass=0
 export task_error=0 # tasks can set this variable to indicate an error

--- a/doc/error-levels
+++ b/doc/error-levels
@@ -8,4 +8,8 @@ errors:                        7xx, 8xx
 The fai-monitor-gui has 4 icons for the error levels.
 
 The variable $STOP_ON_ERROR (default 700) will define that return
-codes that are greater the this value will stop the installation.
+codes that are greater than this value will stop the installation.
+
+The variable $STOP_ON_HOOK_ERROR (default 256) will allow you
+to specify if installation should stop based on a hook error which
+is above this level.

--- a/lib/subroutines
+++ b/lib/subroutines
@@ -285,22 +285,28 @@ call_hook() {
             sendmon "HOOK $hook.$cl.sh"
             # source this hook
             . $hfile.sh $dflag "$@"
-            check_status $hook.$cl.sh $?
+            hook_error=$?
+            check_status $hook.$cl.sh $hook_error
+            [ $hook_error -gt $STOP_ON_HOOK_ERROR ] && stop_fai_installation
         fi
         if [ -x $hfile ]; then
             echo "Calling hook: $hook.$cl"
             sendmon "HOOK $hook.$cl"
             # execute the hook
             $hfile $dflag "$@"
-            check_status $hook.$cl $?
+            hook_error=$?
+            check_status $hook.$cl $hook_error
+            [ $hook_error -gt $STOP_ON_HOOK_ERROR ] && stop_fai_installation
         fi
         # deprecated
-	if [ -x $hfile.source ]; then
+        if [ -x $hfile.source ]; then
             echo "Source hook: $hook.$cl.source"
             sendmon "HOOK $hook.$cl.source"
             # source this hook
             . $hfile.source $dflag "$@"
-            check_status $hook.$cl.source $?
+            hook_error=$?
+            check_status $hook.$cl.source $hook_error
+            [ $hook_error -gt $STOP_ON_HOOK_ERROR ] && stop_fai_installation
         fi
     done
 }


### PR DESCRIPTION
Inspired by #86 after I found that PR didn't work - POSIX limits exit codes to 255, so it isn't possible to use STOP_ON_ERROR, which uses 700 as the threshold.

In my FAI profile I now have a hook that checks to make sure that for a reinstall the selected disk_config won't blow away data on non-operating system disks (being paranoid that a new kernel might detect the disks in a different order), and I wanted to abort the installation in that case. So now we set STOP_ON_HOOK_ERROR=99 and if a failure condition is detected my hook exits with exit code 100.

Worth noting that if STOP_ON_HOOK_ERROR is less than 126 then the installation would also abort if a hook encounters other errors such as missing executable or a signal is received (error code 126 and above), which is probably a sane thing to do.