### PR TITLE
fix setting myip in FAI_CONFIG_SCR in /var/log/fai/variables

### DIFF
--- a/bin/fai-setup
+++ b/bin/fai-setup
@@ -187,7 +187,7 @@ if [ -z "$expert" ]; then
 	opt="dev $SERVERINTERFACE"
     fi
     iprange=$(ip -br ad show $SERVERINTERFACE | awk '{print $3}')
-    myip=$(ip ad show $dev|sed -ne '/127.0.0.1/!{s/^[ \t]*inet[ \t]*\([0-9.]\+\)\/.*$/\1/p}'|head -1)
+    myip=$(echo $iprange | cut -f1 -d"/")
 
     echo "FAI_CONFIGDIR=$FAI_CONFIGDIR" >> /var/log/fai/variables
     echo "FAI_CONFIG_SRC=nfs://${myip}$FAI_CONFIGDIR" >> /var/log/fai/variables


### PR DESCRIPTION
Hello
I'm trying to make fai-server in vagrant (https://github.com/KarolNi/fai_server_vagrant) and had issue with multiple network interfaces (vagrant creates one for internal stuff).
This change fixed it (when $SERVERINTERFACE is set). As far as I could find out $dev was never set.
I think this is the only place affected, but you may look here: https://github.com/faiproject/fai/commit/d26ee406b8653a0bfc9a79255f327f14360cbd52
Also I don't know whether I should write some changelog records