### PR TITLE
Nfsroot without base tar

### DIFF
--- a/bin/fai-make-nfsroot
+++ b/bin/fai-make-nfsroot
@@ -7,8 +7,9 @@
 # This script is part of FAI (Fully Automatic Installation)
 # (c) 2000-2021 by Thomas Lange, lange@informatik.uni-koeln.de
 # Universitaet zu Koeln
-# (c) 2004      by Henning Glawe, glaweh@physik.fu-berlin.de
+# (c) 2004,2021 by Henning Glawe, glaweh@physik.fu-berlin.de
 # Freie Universitaet Berlin
+# Max-Planck-Institut fuer Struktur und Dynamik der Materie, Hamburg
 #
 #*********************************************************************
 # This program is free software; you can redistribute it and/or modify

--- a/bin/fai-make-nfsroot
+++ b/bin/fai-make-nfsroot
@@ -97,11 +97,12 @@ create_base_tar="xz"
 full=1
 
 # option e currently does nothing
-while getopts aghervc:C:B:fkKpPUzsN opt ; do
+while getopts aghervc:C:B:fkKpPUzsNb opt ; do
     case "$opt" in
         a) adjust=1 ;;
         g) generic=1 ;;
         z) create_base_tar="gz" ;;
+        b) create_base_tar="" ;;
         c) classes=$OPTARG
 	   classes=${classes//,/ } ;;
         C) cfdir=$OPTARG ;;

--- a/bin/fai-make-nfsroot
+++ b/bin/fai-make-nfsroot
@@ -93,7 +93,7 @@ sshpreserve=0
 adjust=0
 generic=0
 force=0
-usexz=1
+create_base_tar="xz"
 full=1
 
 # option e currently does nothing
@@ -101,7 +101,7 @@ while getopts aghervc:C:B:fkKpPUzsN opt ; do
     case "$opt" in
         a) adjust=1 ;;
         g) generic=1 ;;
-        z) usexz=0 ;;
+        z) create_base_tar="gz" ;;
         c) classes=$OPTARG
 	   classes=${classes//,/ } ;;
         C) cfdir=$OPTARG ;;
@@ -333,16 +333,14 @@ create_base() {
     call_debootstrap $FAI_DEBOOTSTRAP
     $ROOTCMD apt-get clean
     rm -f $NFSROOT/etc/resolv.conf $NFSROOT/etc/hostname $NFSROOT/etc/udev/rules.d/70-persistent-net.rules
-    if [ $usexz -eq 0 ]; then
-        echo "Creating base.tar.gz"
-    else
-        echo "Creating base.tar.xz"
-    fi
-    tar --xattrs --acls --one-file-system -C $NFSROOT -cf $NFSROOT/var/tmp/base.tar --exclude etc/machine-id --exclude var/tmp/base.tar --exclude 'var/lib/apt/lists/*_*' .
-    if [ $usexz -eq 1 ]; then
-        nice xz -q $NFSROOT/var/tmp/base.tar &
-    else
-        nice gzip $NFSROOT/var/tmp/base.tar &
+    if [ -n "$create_base_tar" ] ; then
+        echo "Creating base.tar.${create_base_tar}"
+        tar --xattrs --acls --one-file-system -C $NFSROOT -cf $NFSROOT/var/tmp/base.tar --exclude etc/machine-id --exclude var/tmp/base.tar --exclude 'var/lib/apt/lists/*_*' .
+        if [ $create_base_tar == "xz" ]; then
+            nice xz -q $NFSROOT/var/tmp/base.tar &
+        else
+            nice gzip $NFSROOT/var/tmp/base.tar &
+        fi
     fi
 }
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/bin/fai-make-nfsroot
+++ b/bin/fai-make-nfsroot
@@ -444,8 +444,8 @@ EOF
 
     # remove file diversion, then create initrd
     rm $NFSROOT/etc/kernel/postinst.d/dracut
-    $ROOTCMD dpkg-divert --rename --remove /etc/kernel/postinst.d/dracut
-    $ROOTCMD dpkg-reconfigure dracut
+    LC_ALL=C $ROOTCMD dpkg-divert --rename --remove /etc/kernel/postinst.d/dracut
+    LC_ALL=C $ROOTCMD dpkg-reconfigure dracut
 
     set_root_pw
 
@@ -531,11 +531,11 @@ add_packages_nfsroot() {
     local err
 
     setclasses
-    install_packages -l -p$cfdir > $NFSROOT/var/tmp/packages.nfsroot
+    LC_ALL=C install_packages -l -p$cfdir > $NFSROOT/var/tmp/packages.nfsroot
     echo "Adding additional packages to $NFSROOT:"
     cat $NFSROOT/var/tmp/packages.nfsroot
     set +e
-    call_verbose install_packages $v -p$cfdir
+    LC_ALL=C call_verbose install_packages $v -p$cfdir
     err=$?
     if [ $err -ne 0 ]; then
 	die 12 "install_packages had exit code: $err"

--- a/conf/NFSROOT
+++ b/conf/NFSROOT
@@ -17,6 +17,7 @@ usbutils pciutils
 ssh
 netselect
 mdadm
+debootstrap # for bootstapping debian/ubuntu systems without a base.tar
 #git # git consumes a lot of disk space on the FAI CD
 
 PACKAGES install-norec

--- a/man/fai-make-nfsroot.8
+++ b/man/fai-make-nfsroot.8
@@ -40,6 +40,9 @@ successfully and >0 if an error occurs.
 .B \-a
 Adjust a generic nfsroot. Add resolv.conf, add host entries, and/or set the root password.
 .TP
+.B \-b
+Do not create the base.tar file.
+.TP
 .B \-B BASETGZ
 Use specified BASETGZ file as base.tgz (or base.tar.gz, base.tar.xz, base.txz)
 for the nfsroot. This avoids


### PR DESCRIPTION
# add option "-b" to fai-make-nfsroot.
When called with '-b', fai-make-nfsroot does not create a base.tar.{gz,xz}.

## changes to NFSROOT package list
Instead of extracting the base system from the base.tar.*, the FAI nfsroot will run ``debootstrap`` to setup the base debian/ubuntu system.

so ``debootstrap`` is added to the default NFSROOT package list (adds 300kB according to apt-cache Installed-Size)

## unrelated changes: LC_ALL=C
when calling some additional commands that involve ``chroot``