### PR TITLE
subroutines: Allow to pass a debootstrap script as well

### DIFF
--- a/lib/subroutines
+++ b/lib/subroutines
@@ -989,8 +989,8 @@ call_debootstrap() {
 	fi
     fi
 
-    echo "Calling $_debootstrap $FAI_DEBOOTSTRAP_OPTS $1 $FAI_ROOT $2"
-    LC_ALL=C $_debootstrap $FAI_DEBOOTSTRAP_OPTS $1 $FAI_ROOT $2
+    echo "Calling $_debootstrap $FAI_DEBOOTSTRAP_OPTS $1 $FAI_ROOT $2 $3"
+    LC_ALL=C $_debootstrap $FAI_DEBOOTSTRAP_OPTS $1 $FAI_ROOT $2 $3
 }
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### BEGIN SUBROUTINE INFO


### PR DESCRIPTION
debootstrap allows to specify the script to use for initial
boostap as 4th argument:

    debootstrap [OPTION...]  SUITE TARGET [MIRROR [SCRIPT]]

This can be helpful when bootstraping a Debian downstream distribution
that doesn't have it's bootstrap script merged (yet) into Debian's
debootstrap but also for experiments without having to patch the host
system.

Allow to pass that boostrap script as well by adding the 3rd argument of
FAI_BOOTSTRAP. Nothing will changes for existing invocations when it's
not set.