### PR TITLE
fix wrong type for holds

### DIFF
--- a/bin/install_packages
+++ b/bin/install_packages
@@ -204,7 +204,7 @@ foreach $atype (@commands) {
     my $packlist = join(' ',@{$pkglist});
 
     if ($atype eq "hold") {
-      my $hold = join " hold\n", @{$list{hold}}, "";
+      my $hold = join " hold\n", @{$list{hold}{$pkgopt}}, "";
       execute("echo \"$hold\" | $rootcmd $command{hold}");
       next;
     }


### PR DESCRIPTION
Throws the rather unhelpful
> Not an ARRAY reference at /usr/sbin/install_packages line 207, <FILE> line 317.

because it's a hash instead of an array.