### PR TITLE
don't mount filesystem types 'nfs4' and 'ceph' in mount2dir

### DIFF
--- a/lib/mount2dir
+++ b/lib/mount2dir
@@ -63,6 +63,8 @@ while read device mountpoint fstype mopt dummy; do
 
     [ "$mountpoint" == "none" ]  && continue
     [ "$fstype" == "nfs" ]  && continue
+    [ "$fstype" == "nfs4" ]  && continue
+    [ "$fstype" == "ceph" ]  && continue
     [ "$fstype" == "swap" ]  && continue
     [ "$fstype" == "proc" ]  && continue
     [ "$fstype" == "usbfs" ]  && continue


### PR DESCRIPTION
both are network filesystems, and the fai nfsroot usually is not configured for cephfs mounting