### PR TITLE
remove unsupported aptitude option '--allow-change-held-packages'

### DIFF
--- a/bin/install_packages
+++ b/bin/install_packages
@@ -61,6 +61,7 @@ my $maxpl;  # maximum length of package list
 my @known;   # list of all known packages
 my $execerrors; # counts execution errors
 my $aptopt='-y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew --allow-change-held-packages';
+my $aptitudeopt='-y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew';
 my $pacmanopts=' --noconfirm ';
 my $downloaddir="/var/cache/apt/archives/partial/"; # where to download packages that gets only unpacked
 my $debsourcesdir='/var/lib/fai/packages';
@@ -86,8 +87,8 @@ our @commands = qw/y2i y2r zypper zypper-pattern zypper-product zypper-rm yast r
            "taskrm" => "tasksel remove",
              "hold" => "dpkg --set-selections",
    "clean-internal" => "apt-get clean",
-         "aptitude" => "aptitude -R $aptopt install",
-       "aptitude-r" => "aptitude -r $aptopt install",
+         "aptitude" => "aptitude -R $aptitudeopt install",
+       "aptitude-r" => "aptitude -r $aptitudeopt install",
               "apt" => "apt $aptopt install",
              "cupt" => "cupt -R $aptopt install",
            "cupt-r" => "cupt $aptopt install",


### PR DESCRIPTION
aptitude gets its own default options, which do not include the ``--allow-change-held-packages`` only supported by ``apt-get``