### PR TITLE
ignore partition type "zfs_member" in fai-mount-disk

### DIFF
--- a/lib/fai-mount-disk
+++ b/lib/fai-mount-disk
@@ -27,6 +27,7 @@ mount_local_disks() {
     for disk in /dev/disk/by-uuid/*; do
         type=$(blkid -sTYPE $disk)
         [[ "$type" =~ "swap" ]] && continue
+        [[ "$type" =~ "zfs_member" ]] && continue
         dev=$(readlink -e $disk)
         devname=${dev##*/}
         mkdir -p $FAI_ROOT/$devname


### PR DESCRIPTION
``blkid`` is now detecting zfs pool/vdev memember partitions as ``zfs_member``, which cannot be mounted individually.

As FAI does not support ZFS, it is safest to ignore such partitions in ``fai-mount-disk``.