### PR TITLE
Update fai-guide.txt install section with debian best practice

### DIFF
--- a/doc/fai-guide.txt
+++ b/doc/fai-guide.txt
@@ -516,8 +516,8 @@ steps are needed:
 
 ----
 # wget -O fai-project.gpg https://fai-project.org/download/2BF8D9FE074BCDE4.gpg
-# cp fai-project.gpg /etc/apt/trusted.gpg.d/
-# echo "deb http://fai-project.org/download bookworm koeln" > /etc/apt/sources.list.d/fai.list
+# mkdir -p /etc/apt/keyrings && mv fai-project.gpg /etc/apt/keyrings
+# echo "deb [signed-by=/etc/apt/keyrings/fai-project.gpg] http://fai-project.org/download bookworm koeln" > /etc/apt/sources.list.d/fai.list
 # apt-get update
 # aptitude install fai-quickstart
 ----


### PR DESCRIPTION
Update inline with https://wiki.debian.org/DebianRepository/UseThirdParty

1. Save to `/etc/apt/keyrings` (_" If it will be managed locally , it SHOULD be downloaded into /etc/apt/keyrings instead."_)
2. Add `signed-by` (_"A sources.list entry SHOULD have the signed-by option set"_)