### PR TITLE
fix .qcow2 image generation via fai-diskimage

### DIFF
--- a/bin/fai-diskimage
+++ b/bin/fai-diskimage
@@ -173,7 +173,7 @@ case "$image" in
         ;;
 
     *.qcow2)
-        copt="-O -c -o compression_type=zstd qcow2 "
+        copt="-O qcow2 -c -o compression_type=zstd "
 	qcowname="$iname.qcow2"
 	;;
 


### PR DESCRIPTION
The parameters to qemu-img convert were in the wrong order and lead to the following error: "qemu-img: Could not open 'qcow2': Could not open 'qcow2': No such file or directory"