### PR TITLE
Save any updated time to hardware

### DIFF
--- a/lib/subroutines
+++ b/lib/subroutines
@@ -483,6 +483,9 @@ task_setup() {
         # set the system time and date using rdate or/and ntpdate
         [ "$TIMESRVS_1" ] && [ -f /bin/rdate ] && rdate $TIMESRVS_1
         [ "$NTPSRVS_1" ]  && ntpdate -b $NTPSRVS
+        # Save the updated time to hardware, so when udevadm trigger
+        # triggers a re-read of the time from rtc, it isn't reset
+        hwclock --systohc
         [ "$flag_createvt" ] && {
             # create two virtual terminals; acces via alt-F2 and alt-F3
             echo "Press ctrl-c to interrupt FAI and to get a shell"


### PR DESCRIPTION
If a machine boots fai, with a hardware clock that's wrong, it can be set correctly by either rdate or ntpdate.

The issue is that with a modern Debian 12, the later call to udevadm trigger will trigger a:
/usr/lib/udev/hwclock-set /dev/rtc0

Where the wrong time is re-read from hardware, thus overwriting the newly corrected time.

This prevent this by just saving the time to hardware after any rdate/ntpdate calls.