### PR TITLE
[RFC] Ignore harmless error

### DIFF
--- a/lib/setup-storage/Volumes.pm
+++ b/lib/setup-storage/Volumes.pm
@@ -116,6 +116,12 @@ sub get_current_disks {
     my $error =
       &FAI::execute_ro_command("parted -sm $disk unit B print", \@parted_print, 0);
 
+      if ($error eq 'parted_3_2') {
+          # Ignore this
+          print "Ignoring error $error\n";
+          $error = '';
+      }
+
     # possible problems
     if (!defined($FAI::configs{"PHY_$disk"}) && $error ne "") {
       warn "Could not determine size and contents of $disk, skipping\n";


### PR DESCRIPTION
I run lvm with pv's on un-partitioned disks.

Unless I ignore this error code here, the searching for labels fails setup-storage.

With this it works as expected, but it's not all that pretty.

The whole error handling from FAI::execute_ro_command is sort of sus, because the error handleing happens directly in that function, so when it detects a warning, it should just warn, and ignore the result.

With this I get:
(CMD) parted -sm /dev/sdb unit B print 1> /tmp/SY_fQFB0P0 2> /tmp/QOgCOzFBVU Executing: parted -sm /dev/sdb unit B print
(STDERR) Error: /dev/sdb: unrecognised disk label
(STDOUT) BYT;
(STDOUT) /dev/sdb:4096805658624B:scsi:512:512:unknown:ATA Samsung SSD 860:; Ignoring error parted_3_2

And the relevant information can be parsed from that.