### PR TITLE
Install_packages doesn't use all it's features on modern debian

### DIFF
--- a/bin/install_packages
+++ b/bin/install_packages
@@ -512,9 +512,9 @@ sub create_debian_pkg_list {
     if (s/^Package: //) {
       $pname{$_} = 1;
     } elsif (s/^Provides: //) {
-	foreach (split /\s*,\s*/) {
-	    $pname{$_} = 1;
-	}
+      foreach (split /\s*,\s*/) {
+        $pname{$_} = 1;
+      }
     }
   }
   close(IN);


### PR DESCRIPTION
There are currently multiple heuristics in `bin/install_packages` to try and detect if the system being installed is debian-like.  
This PR consolidates these heuristics and only uses the one the user has the most control over — whether debian-specific `package_config` commands are used.

Furthermore, when debian specific features were made available (i.e. checking against a list of known packages and consolidating installation and removal requests (`-` at the end)), some more issues needed fixing.

  - purely virtual packages were not indexed into the list of available packages
  - packages specified through environment variables were silently ignored

This PR also addresses these two issues.