### PR TITLE
bin/ifclass: fix quoting in example

### DIFF
--- a/bin/ifclass
+++ b/bin/ifclass
@@ -27,10 +27,12 @@ The list of defined FAI classes must be stored in the variable $classes.
 
 Examples:
 
-$ classes="DEMO AMD64 FAIBASE UBUNTU MINT
+$ classes="DEMO AMD64 FAIBASE UBUNTU MINT"
 $ ifclass 'UBUNTU && ! MINT'
 $ ifclass 'DEMO || MINT'
 $ ifclass 'AMD64 && ( ROCKY || ALMA )'
+
+Note: You need to `export classes` in a login shell.
 
 EOM
   exit 0;


### PR DESCRIPTION
* additionaly add a note that you need to use `export` in a login-shell as bin/ifclass otherwise won't be able to read the variable.