### PR TITLE
call_hook: honor $STOP_ON_ERROR when an executed hook sets task_error

### DIFF
--- a/lib/subroutines
+++ b/lib/subroutines
@@ -353,7 +353,7 @@ call_hook() {
     local hook=$1
     shift
 
-    local cl dflag hfile
+    local cl dflag hfile te
     [ "$debug" ] && dflag="-d"
 
     for cl in $classes; do
@@ -383,6 +383,12 @@ call_hook() {
             # execute the hook
             $hfile $dflag "$@"
             check_status $hook.$cl $?
+            te=$(< $LOGDIR/task_error)
+            if [ "$te" -gt "$STOP_ON_ERROR" ]; then
+                task_error=$te
+                task_error_func=$hook.$cl
+                stop_fai_installation
+            fi
         fi
     done
 }


### PR DESCRIPTION
Debian bug: https://bugs.debian.org/1121552

A hook that runs as a separate process (not a `.sh` sourced hook) executes in a subshell. If it calls `task_error CODE 1` with `CODE > $STOP_ON_ERROR`, `stop_fai_installation` is invoked inside the subshell; in most environments `die` then only replaces the subshell (e.g. `exec bash -i` under nfsroot) or only affects the subshell's state, so the parent FAI process continues running subsequent tasks.

The fix re-reads `$LOGDIR/task_error` after an executed hook returns and calls `stop_fai_installation` from the parent shell if the threshold has been crossed. Sourced `.sh` hooks already run in the parent shell and need no change.