### PR TITLE
get-config-dir: use ln -snf so stale current_config is replaced, not dereferenced

### DIFF
--- a/lib/get-config-dir
+++ b/lib/get-config-dir
@@ -58,7 +58,7 @@ if [ $method = "file" ]; then
     export FAI=$localpath
 fi
 
-ln -sf $FAI /var/run/fai/current_config
+ln -snf $FAI /var/run/fai/current_config
 if [ ! -d $FAI/class ]; then
         echo "WARNING: directory $FAI/class not found."  >&2
         sendmon "TASKERROR get_fai_dir 23"


### PR DESCRIPTION
`ln -sf $FAI /var/run/fai/current_config` dereferences an existing
symlink-to-directory and creates `<FAI>/config -> <FAI>` inside the
config space. `ln -snf` (already used in `bin/fai` and `lib/fai-savelog`)
replaces in place.

Repro:

    mkdir /tmp/cfg
    ln -sf /tmp/cfg /tmp/current
    ln -sf /tmp/cfg /tmp/current   # creates /tmp/cfg/cfg -> /tmp/cfg