### PR TITLE
Add 'read' grub module

### DIFF
--- a/bin/fai-cd
+++ b/bin/fai-cd
@@ -217,7 +217,7 @@ create_grub2_image_x86() {
 	    --format=i386-pc \
 	    --output=/tmp/core.img \
 	    --locales="" --fonts="" \
-	    --install-modules="linux normal iso9660 biosdisk memdisk search ls echo test chain msdospart part_msdos part_gpt minicmd ext2 keystatus all_video font sleep gfxterm regexp" \
+	    --install-modules="linux normal iso9660 biosdisk memdisk search ls echo test chain msdospart part_msdos part_gpt minicmd ext2 keystatus all_video font sleep gfxterm regexp read" \
 	    --modules="linux normal iso9660 biosdisk search" \
 	    "boot/grub/grub.cfg=/tmp/grub.cfg"
 	cat $NEW/usr/lib/grub/i386-pc/cdboot.img $NEW/tmp/core.img > $scratch/bios.img


### PR DESCRIPTION
I have personal use of this module for my FAI cd setup and would like to see it included by default. Since it is such a rudimentary module I do not see any issues with including it.