### PR TITLE
setup-storage: wait for LV device node before using it

### DIFF
--- a/lib/setup-storage/Commands.pm
+++ b/lib/setup-storage/Commands.pm
@@ -648,6 +648,42 @@ sub create_volume_group {
 
 ################################################################################
 #
+# @brief Build a shell command that waits for a device node to appear,
+# bounded by a fixed timeout
+#
+# This works around a well-known device-mapper/udev race condition: right
+# after e.g. lvcreate returns, the kernel has already created the
+# underlying /dev/dm-N device, but the "friendly name" symlinks
+# /dev/<vg>/<lv> (and /dev/mapper/<vg>-<lv>) are only created
+# asynchronously, once udev gets around to processing the corresponding
+# uevent. "udevadm settle" -- which setup-storage already calls before
+# every command -- normally takes care of this, but it relies on a
+# reachable udev daemon and can return prematurely or be a no-op in
+# environments where udev is slow or unreachable, e.g. privileged
+# containers sharing the host's /dev (see
+# https://github.com/rancher/os/issues/838). Polling for the device node
+# itself is environment-agnostic and catches that case too.
+#
+# The wait has to happen at command execution time, between the lvcreate
+# and the mkfs entries of the ordered command queue, and that queue only
+# transports shell command strings; hence this sub returns a shell command
+# for push_command() rather than polling in Perl itself.
+#
+# @param $device Device path that is expected to appear
+#
+# @return Shell command string that succeeds as soon as $device exists,
+# and fails if it is still missing after the timeout
+#
+################################################################################
+sub wait_for_device {
+
+  my ($device) = @_;
+
+  return "timeout 30 sh -c 'until [ -e $device ]; do sleep 1; done'";
+}
+
+################################################################################
+#
 # @brief Create the volume group $config, unless it exists already; if the
 # latter is the case, only add/remove the physical devices
 #
@@ -730,7 +766,13 @@ sub setup_logical_volumes {
     # create a new volume
     &FAI::push_command( "lvcreate $create_options -n $lv -L " .
       &FAI::convert_unit($lv_size->{eff_size} . "B") . " $vg", "vg_enabled_$vg",
-      "exist_/dev/$vg/$lv" );
+      "lv_dev_created_$vg/$lv" );
+
+    # the /dev/$vg/$lv symlink may not exist immediately after lvcreate
+    # returns -- see wait_for_device() for details on why this is needed
+    # in addition to the generic udevadm settle calls
+    &FAI::push_command( &FAI::wait_for_device("/dev/$vg/$lv"),
+      "lv_dev_created_$vg/$lv", "exist_/dev/$vg/$lv" );
 
     # create the filesystem on the volume
     &FAI::build_mkfs_commands("/dev/$vg/$lv",


### PR DESCRIPTION
After lvcreate returns, the kernel has created the underlying `/dev/dm-N` device, but the friendly-name symlinks `/dev/<vg>/<lv>` (and` /dev/mapper/<vg>-<lv>`) are only created asynchronously once udev processes the corresponding uevent. setup-storage already calls "udevadm settle" before every command, but that relies on a reachable, responsive udev daemon and can return prematurely or be a no-op when udev is slow or unreachable -- e.g. in privileged containers sharing the host's /dev (see https://github.com/rancher/os/issues/838) -- which leads to intermittent "`mkfs.ext4: No such file or directory`" failures.

Add wait_for_device(), a small bounded poll loop for the device node itself, and slot it into the LV creation command chain between lvcreate and anything that consumes /`dev/<vg>/<lv>` (mkfs, resize, ...). This is environment-agnostic and catches the case where udevadm settle alone is not sufficient.